### PR TITLE
fix(volsync): switch to longhorn as default storage class

### DIFF
--- a/kubernetes/apps/default/home-assistant/ks.yaml
+++ b/kubernetes/apps/default/home-assistant/ks.yaml
@@ -25,5 +25,3 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_STORAGECLASS: longhorn
-      VOLSYNC_SNAPSHOTCLASS: longhorn

--- a/kubernetes/apps/monitoring/grafana/ks.yaml
+++ b/kubernetes/apps/monitoring/grafana/ks.yaml
@@ -21,8 +21,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 1Gi
-      VOLSYNC_STORAGECLASS: longhorn
-      VOLSYNC_SNAPSHOTCLASS: longhorn
       VOLSYNC_MOVER_FS_GROUP: "472"
       VOLSYNC_MOVER_GROUP: "472"
       VOLSYNC_MOVER_USER: "472"

--- a/kubernetes/templates/volsync/README.md
+++ b/kubernetes/templates/volsync/README.md
@@ -44,4 +44,5 @@ resources:
 - `VOLSYNC_MOVER_GROUP`: Group of the mover's user (default `568`)
 - `VOLSYNC_MOVER_USER`: User to run the mover as (default `568`)
 - `VOLSYNC_SCHEDULE`: Cron expression for the volume sync schedule (default `0 2 * * *`)
-- `VOLSYNC_STORAGECLASS`: The storage class for the PVC (default `local-path`)
+- `VOLSYNC_SNAPSHOTCLASS`: The storage class for volume snapshots (default `longhorn`)
+- `VOLSYNC_STORAGECLASS`: The storage class for the PVC (default `longhorn`)

--- a/kubernetes/templates/volsync/minio.yaml
+++ b/kubernetes/templates/volsync/minio.yaml
@@ -12,11 +12,11 @@ spec:
     copyMethod: "${VOLSYNC_COPYMETHOD:-Snapshot}"
     pruneIntervalDays: 7
     repository: "${APP}-volsync"
-    volumeSnapshotClassName: "${VOLSYNC_SNAPSHOTCLASS:-local-path}"
+    volumeSnapshotClassName: "${VOLSYNC_SNAPSHOTCLASS:-longhorn}"
     cacheCapacity: "${VOLSYNC_CACHE_CAPACITY:-1Gi}"
     cacheStorageClassName: "${VOLSYNC_CACHE_STORAGECLASS:-local-path}"
     cacheAccessModes: ["${VOLSYNC_CACHE_ACCESSMODES:-ReadWriteOnce}"]
-    storageClassName: "${VOLSYNC_STORAGECLASS:-local-path}"
+    storageClassName: "${VOLSYNC_STORAGECLASS:-longhorn}"
     accessModes: ["${VOLSYNC_ACCESSMODES:-ReadWriteOnce}"]
     retain:
       daily: 7
@@ -39,11 +39,11 @@ spec:
   restic:
     copyMethod: "${VOLSYNC_COPYMETHOD:-Snapshot}"
     repository: "${APP}-volsync"
-    volumeSnapshotClassName: "${VOLSYNC_SNAPSHOTCLASS:-local-path}"
+    volumeSnapshotClassName: "${VOLSYNC_SNAPSHOTCLASS:-longhorn}"
     cacheCapacity: "${VOLSYNC_CACHE_CAPACITY:-1Gi}"
     cacheStorageClassName: "${VOLSYNC_CACHE_STORAGECLASS:-local-path}"
     cacheAccessModes: ["${VOLSYNC_CACHE_ACCESSMODES:-ReadWriteOnce}"]
-    storageClassName: "${VOLSYNC_STORAGECLASS:-local-path}"
+    storageClassName: "${VOLSYNC_STORAGECLASS:-longhorn}"
     accessModes: ["${VOLSYNC_ACCESSMODES:-ReadWriteOnce}"]
     capacity: "${VOLSYNC_CAPACITY}"
     moverSecurityContext:

--- a/kubernetes/templates/volsync/pvc.yaml
+++ b/kubernetes/templates/volsync/pvc.yaml
@@ -12,4 +12,4 @@ spec:
   resources:
     requests:
       storage: "${VOLSYNC_CAPACITY}"
-  storageClassName: "${VOLSYNC_STORAGECLASS:-local-path}"
+  storageClassName: "${VOLSYNC_STORAGECLASS:-longhorn}"


### PR DESCRIPTION
volsync does not seem to work at all when `local-path` is the main/snapshot storage class no matter if the `copyMethod` is `Snapshot` or `Clone`.