### PR TITLE
fix(home-assistant): reinstall with privileged volume mover

### DIFF
--- a/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
@@ -72,7 +72,7 @@ spec:
             runAsGroup: 568
             runAsNonRoot: true
             fsGroup: 568
-            fsGroupChangePolicy: OnRootMismatch
+            fsGroupChangePolicy: Always
     service:
       main:
         ports:

--- a/kubernetes/apps/default/home-assistant/code/helmrelease.yaml
+++ b/kubernetes/apps/default/home-assistant/code/helmrelease.yaml
@@ -59,7 +59,7 @@ spec:
             runAsUser: 568
             runAsGroup: 568
             fsGroup: 568
-            fsGroupChangePolicy: OnRootMismatch
+            fsGroupChangePolicy: Always
     service:
       main:
         ports:

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - ./namespace.yaml
   - ./external-apps/ks.yaml
   - ./hajimari/ks.yaml
-  # - ./home-assistant/ks.yaml
+  - ./home-assistant/ks.yaml
   - ./kromgo/ks.yaml
   - ./kubernetes-schemas/ks.yaml
   - ./minio/ks.yaml

--- a/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
@@ -32,6 +32,8 @@ spec:
   values:
     deploymentStrategy:
       type: Recreate
+    securityContext:
+      fsGroupChangePolicy: Always
     admin:
       existingSecret: grafana-admin
     env:

--- a/kubernetes/templates/volsync/minio.yaml
+++ b/kubernetes/templates/volsync/minio.yaml
@@ -46,8 +46,8 @@ spec:
     storageClassName: "${VOLSYNC_STORAGECLASS:-longhorn}"
     accessModes: ["${VOLSYNC_ACCESSMODES:-ReadWriteOnce}"]
     capacity: "${VOLSYNC_CAPACITY}"
-    moverSecurityContext:
-      fsGroup: ${VOLSYNC_MOVER_FS_GROUP:-568}
-      runAsGroup: ${VOLSYNC_MOVER_GROUP:-568}
-      runAsNonRoot: true
-      runAsUser: ${VOLSYNC_MOVER_USER:-568}
+    # moverSecurityContext:
+    #   fsGroup: ${VOLSYNC_MOVER_FS_GROUP:-568}
+    #   runAsGroup: ${VOLSYNC_MOVER_GROUP:-568}
+    #   runAsNonRoot: true
+    #   runAsUser: ${VOLSYNC_MOVER_USER:-568}


### PR DESCRIPTION
This should hopefully circumvent the permission error on `lost+found` while copying back the backup into the volume.