### PR TITLE
feat(minio): use pvc instead of direct nfs mount

### DIFF
--- a/kubernetes/apps/default/minio/app/helmrelease.yaml
+++ b/kubernetes/apps/default/minio/app/helmrelease.yaml
@@ -118,8 +118,6 @@ spec:
     persistence:
       config:
         enabled: true
-        type: nfs
-        server: diskstation.18b.lan
-        path: /volume1/minio
+        existingClaim: minio
         globalMounts:
           - path: /data

--- a/kubernetes/apps/default/minio/app/kustomization.yaml
+++ b/kubernetes/apps/default/minio/app/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./secret.sops.yaml
+  - ./pvc.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/default/minio/app/pvc.yaml
+++ b/kubernetes/apps/default/minio/app/pvc.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: minio
+spec:
+  capacity:
+    storage: 1Mi  # Size does not matter
+  accessModes:
+    - ReadWriteMany
+  storageClassName: minio-nfs
+  persistentVolumeReclaimPolicy: Retain
+  nfs:
+    server: diskstation.18b.lan
+    path: /volume1/minio
+  mountOptions:
+    - nconnect=8
+    - hard
+    - noatime
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: minio-nfs
+  resources:
+    requests:
+      storage: 1Mi  # Size does not matter


### PR DESCRIPTION
This allows for better monitoring of the storage and also give the ability to configure the nfs mount options.