### PR TITLE
feat(kubernetes): install alertmanager

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -33,7 +33,30 @@ spec:
       enabled: true
     cleanPrometheusOperatorObjectNames: true
     alertmanager:
-      enabled: false
+      ingress:
+        enabled: true
+        pathType: Prefix
+        ingressClassName: internal
+        annotations:
+          hajimari.io/appName: Alertmanager
+          hajimari.io/group: observability
+          hajimari.io/icon: simple-icons:prometheus
+        hosts:
+          - &host alertmanager.18b.haus
+        tls:
+          - hosts:
+              - *host
+      alertmanagerSpec:
+        replicas: 2
+        useExistingSecret: true
+        configSecret: alertmanager-secret
+        storage:
+          volumeClaimTemplate:
+            spec:
+              storageClassName: local-path
+              resources:
+                requests:
+                  storage: 100Mi
     prometheus-node-exporter:
       fullnameOverride: node-exporter
       prometheus:

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
@@ -5,3 +5,9 @@ kind: Kustomization
 resources:
   - ./helmrelease.yaml
   - ./scrapeconfigs
+secretGenerator:
+  - name: alertmanager-secret
+    files:
+      - alertmanager.yaml=./resources/alertmanager.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/resources/alertmanager.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/resources/alertmanager.yaml
@@ -1,0 +1,31 @@
+---
+global:
+  resolve_timeout: 5m
+route:
+  group_by: ["alertname", "job"]
+  group_interval: 10m
+  group_wait: 1m
+  receiver: "null"
+  repeat_interval: 12h
+  routes:
+    - receiver: "null"
+      group_interval: 5m
+      group_wait: 0s
+      matchers:
+        - alertname =~ "Watchdog"
+      repeat_interval: 5m
+    - receiver: "null"
+      matchers:
+        - alertname =~ "InfoInhibitor"
+    - receiver: "null"
+      continue: true
+      matchers:
+        - severity = "critical"
+inhibit_rules:
+  - equal: ["alertname", "namespace"]
+    source_matchers:
+      - severity = "critical"
+    target_matchers:
+      - severity = "warning"
+receivers:
+  - name: "null"


### PR DESCRIPTION
Updates https://github.com/martinohmann/home-ops/issues/213

Just installs alertmanagers and null-routes all alerts. Configuration for more useful receiver(s) will be added in a followup.