### PR TITLE
fix(home-assistant): make pvc RWO

### DIFF
--- a/kubernetes/apps/default/home-assistant/ks.yaml
+++ b/kubernetes/apps/default/home-assistant/ks.yaml
@@ -24,6 +24,5 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_ACCESSMODES: ReadWriteMany
       VOLSYNC_CAPACITY: 5Gi
       VOLSYNC_MOVER_USER: "0"


### PR DESCRIPTION
The gets rid of the longhorn share-manager instance in the cluster which caused me some trouble with crashing nodes in the past.