### PR TITLE
fix(kube-prometheus-stack): override operator name

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -206,6 +206,8 @@ spec:
               resources:
                 requests:
                   storage: 10Gi
+    prometheusOperator:
+      fullnameOverride: prometheus-operator
     grafana:
       enabled: false
       forceDeployDashboards: true


### PR DESCRIPTION
Short and clean

This is now possible due to https://github.com/prometheus-community/helm-charts/pull/4219