### PR TITLE
feat(home-assistant): add CoIoT service load balancer

### DIFF
--- a/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
@@ -98,6 +98,16 @@ spec:
             port: 8123
           code:
             port: 80
+      coiot:
+        controller: home-assistant
+        type: LoadBalancer
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: home-assistant-coiot.18b.haus
+          io.cilium/lb-ipam-ips: 192.168.40.248
+        ports:
+          coiot:
+            protocol: UDP
+            port: 5683
     ingress:
       app:
         enabled: true


### PR DESCRIPTION
CoIoT is used by shelly devices to report state back to home assistant.