### PR TITLE
fix(zigbee2mqtt) switch to exec probes

### DIFF
--- a/kubernetes/apps/default/zigbee2mqtt/app/helmrelease.yaml
+++ b/kubernetes/apps/default/zigbee2mqtt/app/helmrelease.yaml
@@ -78,10 +78,22 @@ spec:
                 drop:
                   - ALL
             probes:
-              liveness:
+              liveness: &probe
                 enabled: true
-              readiness:
-                enabled: true
+                custom: true
+                spec:
+                  failureThreshold: 3
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  exec:
+                    command:
+                      - wget
+                      - --no-verbose
+                      - --tries=1
+                      - --spider
+                      - http://localhost:80
+              readiness: *probe
             resources:
               requests:
                 cpu: 10m


### PR DESCRIPTION
The pod sometimes end up in Error state when it loses its connection to the zigbee coordinator and does not recover automatically. I suspect that this is due to misconfigured probes, so let's try a different configuration.