### PR TITLE
fix(zigbee2mqtt): make gatus bypass auth proxy

### DIFF
--- a/kubernetes/apps/default/zigbee2mqtt/app/gatus-ep.yaml
+++ b/kubernetes/apps/default/zigbee2mqtt/app/gatus-ep.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zigbee2mqtt-gatus-ep
+  labels:
+    gatus.io/enabled: "true"
+data:
+  config.yaml: |
+    endpoints:
+      - name: zigbee2mqtt
+        group: internal
+        url: http://zigbee2mqtt.default.svc.cluster.local
+        interval: 2m
+        ui:
+          hide-hostname: true
+          hide-url: true
+        client:
+          dns-resolver: tcp://192.168.40.251:53  # k8s-gateway
+        conditions:
+          - "[STATUS] == 200"
+        alerts:
+          - type: telegram
+      - name: zigbee2mqtt
+        group: guarded
+        url: 1.1.1.1
+        interval: 1m
+        ui:
+          hide-hostname: true
+          hide-url: true
+        dns:
+          query-name: zigbee.18b.haus
+          query-type: A
+        conditions:
+          - "len([BODY]) == 0"
+        alerts:
+          - type: telegram
+            description: exposed to the internet

--- a/kubernetes/apps/default/zigbee2mqtt/app/kustomization.yaml
+++ b/kubernetes/apps/default/zigbee2mqtt/app/kustomization.yaml
@@ -5,5 +5,5 @@ kind: Kustomization
 resources:
   - ./secret.sops.yaml
   - ./helmrelease.yaml
-  - ../../../../templates/gatus/internal
+  - ./gatus-ep.yaml
   - ../../../../templates/volsync

--- a/kubernetes/apps/default/zigbee2mqtt/ks.yaml
+++ b/kubernetes/apps/default/zigbee2mqtt/ks.yaml
@@ -22,7 +22,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      GATUS_SUBDOMAIN: zigbee
       VOLSYNC_CAPACITY: 1Gi
       VOLSYNC_SCHEDULE_B2: '15 2 * * 0'
       VOLSYNC_SCHEDULE_MINIO: '15 2 * * *'


### PR DESCRIPTION
Probing zigbee.18b.haus actually tests the authentik-output-proxy instead of zigbee2mqtt. We're going to switch to the internal endpoint to test that it's up.