### PR TITLE
feat(kube-web-view): integrate storage cluster

### DIFF
--- a/kubernetes/main/apps/monitoring/kube-web-view/app/helmrelease.yaml
+++ b/kubernetes/main/apps/monitoring/kube-web-view/app/helmrelease.yaml
@@ -34,6 +34,7 @@ spec:
               repository: hjacobs/kube-web-view
               tag: 23.8.0
             args:
+              - --clusters=main=http://localhost:8001;storage=http://localhost:8002
               - --port=8080
               - --show-container-logs
             probes:
@@ -50,6 +51,49 @@ spec:
               requests:
                 cpu: 5m
                 memory: 100Mi
+          proxy-main:
+            image:
+              repository: docker.io/bitnami/kubectl
+              tag: 1.29.4
+            args:
+              - --port=8001
+            probes:
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /readyz
+                    port: 8001
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /livez
+                    port: 8001
+          proxy-storage:
+            image:
+              repository: docker.io/bitnami/kubectl
+              tag: 1.29.4
+            args:
+              - --kubeconfig=/kubeconfig
+              - --port=8002
+            probes:
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /readyz
+                    port: 8002
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /livez
+                    port: 8002
     pod:
       securityContext:
         readOnlyRootFilesystem: true
@@ -82,3 +126,12 @@ spec:
         tls:
           - hosts:
               - *host
+    persistence:
+      storage-auth:
+        type: secret
+        name: kube-web-view-storage-auth
+        advancedMounts:
+          kube-web-view:
+            proxy-storage:
+              - path: /kubeconfig
+                subPath: kubeconfig

--- a/kubernetes/main/apps/monitoring/kube-web-view/app/kustomization.yaml
+++ b/kubernetes/main/apps/monitoring/kube-web-view/app/kustomization.yaml
@@ -3,5 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./secret.sops.yaml
   - ./rbac.yaml
   - ./helmrelease.yaml

--- a/kubernetes/main/apps/monitoring/kube-web-view/app/secret.sops.yaml
+++ b/kubernetes/main/apps/monitoring/kube-web-view/app/secret.sops.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: kube-web-view-storage-auth
+stringData:
+    kubeconfig: ENC[AES256_GCM,data:X8yY/6izsx/myaSUXZydGQa3if60L+BTQvIF1STC76kA6l/u6wASsBtkzge6SVp8lyZ9DBeGRMxGgZkFosrNtttVQdY/nq/hGNZJOEldaH1bIvvDGRHg1UPHOrBi1+izEYaU8rGJOsq088/631bse8E3CBjymxTkC0m3smDufF5V2F2p7ZU0gLmnCWWac+2kNfRvyzzxXZJkQQpHMxstVnwfjYdrPS3bULi11f5CtIgeNZJhxdp+qMVnexQAvUie9SrKhNuR721Hm7S4UGWXhKfBcDqi+bFy2lBCYbQ2Xbg7aN7aG+LoeKcbTb79E7sMAY5k/UJ9zWb3KxLrd37cQZhdLtYT7pNZ7lZaa+WpTixBHBgKc2HQSmz2/UmjAbJ+YX0BE8NdXPnLsqSPS5jxYrvtw/9+ps+MlU7Et2cilR4Udz1U2ct/voWZ/En+APBnNUStNJ9t3PmQ2Ur+PGwiBxjJyochngeGSB33PfjTO7BGoHlifp5etJHBjUOv7LTERTf/mAHJjlklKZqblA7cGRzbH7dv+iqWSYnBgPpq0q/mJSxCge3oird3TJp5WaxNCT3M7hTZuvTr8lduOj4fG2rWD6KnDVQ3WieLI6Kecfuf0XE8cILKr5MtixU9yB6p83trygRXhTM0zf/SHDs4AirmY5zAjzI/xFCIf6kDA+n+sXrI87UbNbfxo5iGNJ8EIJIrw8rxUESJENS4qxuWNpQERjjSgsQauSx5qGLPr3yCZfQgeIaOg63Ct9I6fewaGVAocYAGzx5bOPZ1QJBisoS3ISeIBboa1Xb1gbtucHBYZUB4eQe/wYJHFzZzy/jIcO3kMsvLN1R/Ch6bJblo+l22fNo0UgJifkENrlymMmvhTs836OUi8gqczOXw/CbF549aH2QsFNxW/sF8ksYj5YLrKBGID7k5UuDKCE41MfrrRIxDdHPf9EpuuU+tayOms5lTbfkZieZbsQ0ajpYIgWrJp0/tPbPPrVPcDsZEn5voy6W9Lhm2K6oKzdRiMi2jcwoYAXWhV8WPwnKSGI6n2LeTmswiaPa3nLw+OkwpbE4SMsGQ0oMfnYOdC62Vt9/k4wOkHpKr83IwzAufQpzge1bmYMoeK+HewbcAET/WdptjfxFwZ0wyLvDkzqARRRk1mZxkearFISzh+V7BlFNYJ0g2qZ6iCHuwHd9fdtuYqubdhwMvPlU0hzc0XBqvgATfbSvEjhIdCt0DgvE0dWqlZ4JL3GV4cced3tV40vMF02qFcWOPPt+GoFvTWUUw8lrlJRDip1jIMIffDI/uI5tx6XJGS041NmJbSA9ibPCdrwI5ECztx/JyMK0Al/IFzajzhgu0v0ckS0ZK+DuGpZoGqvA5vfL//bzOm1YtcWXM5UJsbbIM7ZCnNBPe6m5YW2yj9JEYp2IOyWp8TOquC8824/5gb7tKW08EOZ8/YRNtibFzhyKbV9cBPZj4q4Vnxw7Cz2jA61Q80lt9d/fWDHYqxApoTkBWs6ltwZGD2jJc2CAzFr4Y27pX1rxUBZMLtmCI9F/YfMsbFGFgSL2X955WttYFBxvPz5OXgsKs+njRmqHC/l8HhVsEc1mxPaehlYRmps3fCYptjOpgsWyZTxh+r8ShkyK8cGPWTVzTC3ze7n0rf7MRhZLNsgedqV+AlJyZ6rW4EauNPdqf+n3kU3BWtKBGBDLDGMMXCkjvSL5FKqBVmqUtc6HcpmrnJ6efxN0VYyWfNE1fPa7p/Cit4xfspcPC/WYLQGZIhlrNIscRn0MJzOJSADnJvYqDr7ow3LPfUJzNJVyHPRI02ScyLsVI6nPKwO/VmyV972qZYIEixT2q/43AqtLpe/Ue4P2G480zNe/gP3IqL46EfU5lmu2eahIUQdtCgBdraBfEVpdjQH0IZkNmgzMy91P+Y2aclAJCyKVOFinYk3CKuPd4vFo4p2zqdcMLZkGyFYlAp8Ig5ZFyBgsFQgdaBKO/0Sjo4qDBiKodfWBqoySZMSseHUvEZJcuu+RjQNph271hQZcZBdh0Tn8rYYy10Ny0r38nUtHBicRIGTofArIafVtFas7FqPaqFkgfU9Xea6WkNB/ykLwiha2jh62yNqnArhNwzoOSoDXPFkeBPnQSa+Rpt/ryq3CDOCGmNHl0UYAgrDR3wal8GA6WGZw76yFwrEG5B/vdRHgAqF2SYP0BnhzFsm7HnO0y33rT1KWpMBDlYuVafZh9JJ4TP7c1BdKFL0fLoql6kSjLRJwAirwEhlYDzteGehiGmue+vnXIMaDS6VPDfbUMooFBJtSKNgDaYl6mzSiD/D2GUxlAJydJ8PfC+cJXF/xEkHcLaHtkCkiXEDuqwudO0fLc/NT2BkJOjxE9Gq53azvCG0JHGRlndVdWaZFXRE27p5y+aBms3zzyRrOu1GJend5AOiTQZR0EKjiMKvkQ2V4ToxLPZDgBCJsoHZyl8+I2wUnZljTmrWGDs/6PB/mty/NgglNJZlSoGW9W87t5aaCUXaudU6B3D6BQl1pyCNS08o0YcMM34oDFT4HT56SaiMErVqwFKksUDznd4v3Vi5Htw4LwtY2ueRsi8IDAjzifTk7oiwF/BpIa2p2Zm7uN/vvCQzASz+JIh1inSEX7DMF8BxZqOX9hth2krQ==,iv:qY1J9npbexZtMPYJRtQL7PQ93wW9qJHnk1/Kz8zDR0k=,tag:0gJ57bgAM3h4Rtt1txKGUw==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1u79ltfzz5k79ddwgv59r76p2532xnaehzz7vggttctudr6gdkvhq33edn6
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvbDdHM3hKSzdEY3VlYW45
+            ZGVyV3NXQm15cEt2Y0hOYllyd2NaZC9GeXhJCjhRMHZJWGZLejZ6bVBjQVJqMHFk
+            VjJ5ZjA2bnl2bFFxOFcyZFFsNW8rM00KLS0tIEFxYi9YZEZ5S3UxQW9iTUlDc1V0
+            elJ0dnJXalFDK095S0tPRWdwdURUZjAKlKu0DHKGUQXngvp0yq7snAsnz0WMumeZ
+            PKcFowo4H0ilPO+W2da8ltJ8YYoZpmzdUyIH5gW0V3+vW2msT5NuuQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2024-04-18T19:33:39Z"
+    mac: ENC[AES256_GCM,data:gQrVc0DpnVZLyrGIdNdUpOUsO6Q8c4qb03Tk612vTGy/EUW907nygskhI1NkdYxpug3fJtQEy2nCkZ0PHiIecTb2Hpyot8EsG8lJBlIEFP7Ry0PbpkzCawF5DP+80sLrKptd8EP6yHA5HXegTqPkFAHUCv5uoS/QjLqetgFS/AA=,iv:/YWl+INJ66uGkv9ZWcWCGvHw+gy/WvxVwMHdhv6SETA=,tag:OVp2GJ82HajJQ1iM+RKFmQ==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.8.1


### PR DESCRIPTION
Closes https://github.com/martinohmann/home-ops/issues/656

Integrates storage cluster into kube-web-view.

This is the second attempt since the first one failed because `kube-web-view` does not support the `tokenFile` kubeconfig field.

We're using auth via two proxy sidecars instead. `proxy-main` connects to the local cluster's API via the pod's serviceaccount token, while `proxy-storage` uses a kubeconfig with the token and CA data of the storage cluster.