### PR TITLE
chore(minio): migrate traffic to storage cluster

### DIFF
--- a/kubernetes/main/apps/argo/argo-workflows/app/helmrelease.yaml
+++ b/kubernetes/main/apps/argo/argo-workflows/app/helmrelease.yaml
@@ -74,8 +74,8 @@ spec:
           archiveLogs: true
           s3:
             bucket: argo-workflow-artifacts
-            endpoint: minio.default.svc.cluster.local:9000
-            insecure: true
+            endpoint: s3.storage.18b.haus
+            insecure: false
             accessKeySecret:
               name: argo-minio-credentials
               key: access-key-id

--- a/kubernetes/main/apps/database/cloudnative-pg/cluster/cluster16.yaml
+++ b/kubernetes/main/apps/database/cloudnative-pg/cluster/cluster16.yaml
@@ -34,7 +34,7 @@ spec:
         compression: bzip2
         maxParallel: 8
       destinationPath: s3://cloudnative-pg/
-      endpointURL: https://s3.18b.haus
+      endpointURL: https://s3.storage.18b.haus
       # Note: serverName version needs to be inclemented
       # when recovering from an existing cnpg cluster
       serverName: &currentCluster postgres16-v2

--- a/kubernetes/main/apps/default/gitea/app/helmrelease.yaml
+++ b/kubernetes/main/apps/default/gitea/app/helmrelease.yaml
@@ -116,9 +116,9 @@ spec:
           PROVIDER_CONFIG: redis://:@gitea-redis-headless.default.svc.cluster.local:6379/0?pool_size=100&idle_timeout=180s
         storage:
           STORAGE_TYPE: minio
-          MINIO_ENDPOINT: minio.default.svc.cluster.local:9000
+          MINIO_ENDPOINT: s3.storage.18b.haus
           MINIO_BUCKET: gitea
-          MINIO_USE_SSL: false
+          MINIO_USE_SSL: true
         webhook:
           ALLOWED_HOST_LIST: private
       metrics:

--- a/kubernetes/main/apps/default/static-content-proxy/app/resources/nginx.conf
+++ b/kubernetes/main/apps/default/static-content-proxy/app/resources/nginx.conf
@@ -20,7 +20,7 @@ http {
     location / {
       proxy_hide_header "Set-Cookie";
       proxy_intercept_errors on;
-      proxy_pass http://minio.default.svc.cluster.local:9000/static-content/;
+      proxy_pass https://s3.storage.18b.haus/static-content/;
     }
   }
 }

--- a/kubernetes/main/templates/volsync/secret.yaml
+++ b/kubernetes/main/templates/volsync/secret.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: "${APP}-volsync"
 stringData:
-  RESTIC_REPOSITORY: "s3:http://minio.default.svc.cluster.local:9000/volsync/${APP}"
+  RESTIC_REPOSITORY: "s3:https://s3.storage.18b.haus/volsync/${APP}"
   RESTIC_PASSWORD: "${SECRET_RESTIC_PASSWORD}"
   AWS_ACCESS_KEY_ID: "${SECRET_VOLSYNC_MINIO_ACCESS_KEY_ID}"
   AWS_SECRET_ACCESS_KEY: "${SECRET_VOLSYNC_MINIO_SECRET_ACCESS_KEY}"


### PR DESCRIPTION
The old and new minio instances are already replicating between each other, so this change should be really unproblematic.