### PR TITLE
feat(terraform): use kubernetes state backend

### DIFF
--- a/terraform/.envrc
+++ b/terraform/.envrc
@@ -7,3 +7,5 @@ use_sops() {
   fi
   watch_file "$path"
 }
+
+export KUBE_CONFIG_PATH="$(expand_path ../kubernetes/kubeconfig)"

--- a/terraform/authentik/versions.tf
+++ b/terraform/authentik/versions.tf
@@ -1,4 +1,10 @@
 terraform {
+  backend "kubernetes" {
+    config_context = "storage"
+    namespace      = "terraform"
+    secret_suffix  = "authentik"
+  }
+
   required_providers {
     authentik = {
       source  = "goauthentik/authentik"

--- a/terraform/cloudflare/versions.tf
+++ b/terraform/cloudflare/versions.tf
@@ -1,4 +1,10 @@
 terraform {
+  backend "kubernetes" {
+    config_context = "storage"
+    namespace      = "terraform"
+    secret_suffix  = "cloudflare"
+  }
+
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"

--- a/terraform/minio/versions.tf
+++ b/terraform/minio/versions.tf
@@ -1,4 +1,10 @@
 terraform {
+  backend "kubernetes" {
+    config_context = "storage"
+    namespace      = "terraform"
+    secret_suffix  = "minio"
+  }
+
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/terraform/proxmox/versions.tf
+++ b/terraform/proxmox/versions.tf
@@ -1,4 +1,10 @@
 terraform {
+  backend "kubernetes" {
+    config_context = "storage"
+    namespace      = "terraform"
+    secret_suffix  = "proxmox"
+  }
+
   required_providers {
     http = {
       source  = "hashicorp/http"


### PR DESCRIPTION
Closes https://github.com/martinohmann/home-ops/issues/129

I'm storing the state inside the storage cluster and additionally have `terraform-state-sync` deployed in the `terraform` namespace, which syncs the state secrets to minio so that I could recover them from disk if I break the cluster. This helps working around the hen-egg problem.