### PR TITLE
feat(storage): prepare short ingress domains

### DIFF
--- a/kubernetes/storage/apps/default/filebrowser/app/helmrelease.yaml
+++ b/kubernetes/storage/apps/default/filebrowser/app/helmrelease.yaml
@@ -93,7 +93,13 @@ spec:
           nginx.ingress.kubernetes.io/auth-snippet: |
             proxy_set_header X-Forwarded-Host $http_host;
         hosts:
-          - host: &host filebrowser.storage.18b.haus
+          - host: &host filebrowser.18b.haus
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+          - host: &storageHost filebrowser.storage.18b.haus
             paths:
               - path: /
                 service:
@@ -102,6 +108,7 @@ spec:
         tls:
           - hosts:
               - *host
+              - *storageHost
     persistence:
       config:
         existingClaim: filebrowser

--- a/kubernetes/storage/apps/default/kopia/app/helmrelease.yaml
+++ b/kubernetes/storage/apps/default/kopia/app/helmrelease.yaml
@@ -96,7 +96,13 @@ spec:
           nginx.ingress.kubernetes.io/auth-snippet: |
             proxy_set_header X-Forwarded-Host $http_host;
         hosts:
-          - host: &host kopia.storage.18b.haus
+          - host: &host kopia.18b.haus
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+          - host: &storageHost kopia.storage.18b.haus
             paths:
               - path: /
                 service:
@@ -105,6 +111,7 @@ spec:
         tls:
           - hosts:
               - *host
+              - *storageHost
     persistence:
       config-file:
         type: secret

--- a/kubernetes/storage/apps/default/minio/app/helmrelease.yaml
+++ b/kubernetes/storage/apps/default/minio/app/helmrelease.yaml
@@ -98,13 +98,25 @@ spec:
         enabled: true
         className: internal
         hosts:
-          - host: &host minio.storage.18b.haus
+          - host: &host minio.18b.haus
             paths:
               - path: /
                 service:
                   identifier: app
                   port: http
-          - host: &s3Host s3.storage.18b.haus
+          - host: &s3Host s3.18b.haus
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: s3
+          - host: &storageHost minio.storage.18b.haus
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+          - host: &s3StorageHost s3.storage.18b.haus
             paths:
               - path: /
                 service:
@@ -114,6 +126,8 @@ spec:
           - hosts:
               - *host
               - *s3Host
+              - *storageHost
+              - *s3StorageHost
     persistence:
       config:
         type: hostPath

--- a/kubernetes/storage/apps/default/zot/app/helmrelease.yaml
+++ b/kubernetes/storage/apps/default/zot/app/helmrelease.yaml
@@ -88,7 +88,13 @@ spec:
           nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
           nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
         hosts:
-          - host: &host registry.storage.18b.haus
+          - host: &host registry.18b.haus
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+          - host: &storageHost registry.storage.18b.haus
             paths:
               - path: /
                 service:
@@ -97,6 +103,7 @@ spec:
         tls:
           - hosts:
               - *host
+              - *storageHost
     persistence:
       config:
         type: configMap


### PR DESCRIPTION
The `storage` subdomain not needed, unless for name collisions with the main cluster (e.g. `prometheus.18b.haus` vs. `prometheus.storage.18b.haus`).

I want to use shorter DNS names where possible. This adds them already. Consumers of these services will be updated in a followup.