### PR TITLE
chore(authentik): switch cache backend to dragonfly

### DIFF
--- a/kubernetes/main/apps/identity/authentik/app/helmrelease.yaml
+++ b/kubernetes/main/apps/identity/authentik/app/helmrelease.yaml
@@ -24,6 +24,10 @@ spec:
       log_level: debug
       error_reporting:
         enabled: false
+      redis:
+        host: dragonfly.database.svc.cluster.local
+        port: 6379
+        db: 2
     server:
       annotations:
         secret.reloader.stakater.com/reload: &secret authentik-secret
@@ -74,37 +78,7 @@ spec:
       rules:
         enabled: true
     redis:
-      enabled: true
-      auth:
-        enabled: true
-      master:
-        persistence:
-          enabled: true
-          storageClass: longhorn
-          size: 1Gi
-        resources:
-          requests:
-            cpu: 15m
-            memory: 20Mi
-          limits:
-            memory: 60Mi
-      commonConfiguration: |-
-        # Enable AOF https://redis.io/topics/persistence#append-only-file
-        appendonly yes
-        # Disable RDB persistence, AOF persistence already enabled.
-        save ""
-        maxmemory 94371840
-        maxmemory-policy allkeys-lru
-      metrics:
-        enabled: true
-        serviceMonitor:
-          enabled: true
-        resources:
-          requests:
-            cpu: 10m
-            memory: 10Mi
-          limits:
-            memory: 20Mi
+      enabled: false
   valuesFrom:
     - kind: Secret
       name: *secret
@@ -114,10 +88,6 @@ spec:
       name: *secret
       valuesKey: REDIS_PASSWORD
       targetPath: authentik.redis.password
-    - kind: Secret
-      name: *secret
-      valuesKey: REDIS_PASSWORD
-      targetPath: redis.auth.password
     - kind: Secret
       name: *secret
       valuesKey: INIT_POSTGRES_HOST

--- a/kubernetes/main/apps/identity/authentik/app/secret.sops.yaml
+++ b/kubernetes/main/apps/identity/authentik/app/secret.sops.yaml
@@ -8,7 +8,7 @@ stringData:
     INIT_POSTGRES_PASS: ENC[AES256_GCM,data:6B3laoW3bTvFtha4bUT5vv04aVieeef0,iv:FB7esh7ivfz4RYFgK0RCL/L3phv9c6/9f6key8Thtkk=,tag:FvGnQVuphK463bcH9qgxzw==,type:str]
     INIT_POSTGRES_SUPER_PASS: ENC[AES256_GCM,data:VcGOw+GfWp3UUvO6368Yt5y56D+JmYb7GAVDpvfQAX2t,iv:02KCwA46nzX8rq3A6Wci8KotAZjr9nnEXxr/QGn7vKg=,tag:zMPbDLfLYgq0hnOp2VTF4w==,type:str]
     INIT_POSTGRES_USER: ENC[AES256_GCM,data:c0NYVxhkMl2A,iv:rbqXHK8MTq0XovS7Nd4+7Ts3EjeQUps8zYmeTf/beIE=,tag:kTz6upYh9nU5wsgHXxgD3w==,type:str]
-    REDIS_PASSWORD: ENC[AES256_GCM,data:v8qXmmu8xkw+ocj4Wa3hZbrWhhZS4eoY,iv:rzRLZJZBlHF2bspvI1hsd3vO54I4YySi/SELHXHEgDA=,tag:OhAYThd84tTZIG7UzsKxNQ==,type:str]
+    REDIS_PASSWORD: ENC[AES256_GCM,data:6oH8K/Nf223e5DzkszCZsI5VG6BGFiN7FtYPFGNIMYTrxvqI,iv:AqkKZVkh1MR6+hn1a+QAbQ8edBSEh5DdHYRPGqCmyL4=,tag:IeoM3xpS+S7KGknIrn550w==,type:str]
     SECRET_KEY: ENC[AES256_GCM,data:ZAdt5u+gBsHps/HcEtTNbFsx1Ulrs5Osgocw/ueHdK2+u81WjLdB/r2b6NXLgFxYi3s=,iv:Uwn4MSCcikcevZ8S6AjlGAgZv4XV+8nzeAoNvrMsX4U=,tag:NEiVeGw6U0JrvIQmbGFxWw==,type:str]
 sops:
     kms: []
@@ -25,8 +25,8 @@ sops:
             ekoxSWY2dmlWK0k3bzhUdmo0ZzdvTzQKlBZSUqKIS0zDPmYiyDX/ynsV++620De6
             FT3clq2Hev74lzkqV2NKjuJNkuPFIxSAPoySw0VYWbrxCS1ztWs8wg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-01-05T13:02:06Z"
-    mac: ENC[AES256_GCM,data:ErHphxf/T84T08gdjvz0R5j42G4YD0wkMUBmiAsz4QlXKoTEOn6bjNO7HeqV16m0tQmwl0fEEOaQTiK151IZXJFAeukVxq5d6MoiI0VRO9l9BnW9+KmSGROHrjMEJJjQw4fsZw8JGjf42BjLDhSoJDS212QdWl2M+1C5c8w5iN8=,iv:mYmSuOqqngrfKhsQ+MAEPDmqCOvmbIXGH2oQWsiNXbA=,tag:skCqeGQjVVIk/MYkByVG6A==,type:str]
+    lastmodified: "2024-05-27T19:10:21Z"
+    mac: ENC[AES256_GCM,data:erpiOPPJmAb0g/y3OUf5ex9bRPErm5MK3zBy6q2W+0+womc8YDrwfCuGFJcwPvpj9d22eBBzP/LT8AleNnwh7it24hOOwxY4ImqQ7Pvt28J36uFDwfnhv2iBBkYvXLd1oCgRx0Q/1Z+JTi6yFa6+sWM3aOWPnfZFFZNeRRAB5G8=,iv:1FSdzPgb+h7hE2HyL6YGwJaC45zSZO7NRaYrh2SKwUE=,tag:58RrxNVcB188XNbObkjD0w==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.8.1


### PR DESCRIPTION
Closes https://github.com/martinohmann/home-ops/issues/670