### PR TITLE
fix(kube-prometheus-stack): bring back pre-63.x matching behaviour

### DIFF
--- a/kubernetes/main/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/main/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -217,6 +217,16 @@ spec:
               resources:
                 requests:
                   storage: 20Gi
+        podMonitorSelector:
+          matchLabels: null
+        probeSelector:
+          matchLabels: null
+        ruleSelector:
+          matchLabels: null
+        scrapeConfigSelector:
+          matchLabels: null
+        serviceMonitorSelector:
+          matchLabels: null
         thanos:
           image: quay.io/thanos/thanos:${THANOS_VERSION}
           version: "${THANOS_VERSION#v}"

--- a/kubernetes/storage/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/storage/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -139,6 +139,16 @@ spec:
               resources:
                 requests:
                   storage: 20Gi
+        podMonitorSelector:
+          matchLabels: null
+        probeSelector:
+          matchLabels: null
+        ruleSelector:
+          matchLabels: null
+        scrapeConfigSelector:
+          matchLabels: null
+        serviceMonitorSelector:
+          matchLabels: null
         thanos:
           image: quay.io/thanos/thanos:${THANOS_VERSION}
           version: "${THANOS_VERSION#v}"


### PR DESCRIPTION
This PRs broke the discovery of a lot of pod and service monitors:

https://github.com/martinohmann/home-ops/pull/1412 https://github.com/martinohmann/home-ops/pull/1413

This restores the old matching behaviour.