### PR TITLE
fix(cilium): set `socketLB.hostNamespaceOnly` to `true`

### DIFF
--- a/kubernetes/main/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/main/apps/kube-system/cilium/app/helmrelease.yaml
@@ -118,3 +118,5 @@ spec:
     routingMode: native
     securityContext:
       privileged: true
+    socketLB:
+      hostNamespaceOnly: true

--- a/kubernetes/storage/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/storage/apps/kube-system/cilium/app/helmrelease.yaml
@@ -70,3 +70,5 @@ spec:
     routingMode: native
     securityContext:
       privileged: true
+    socketLB:
+      hostNamespaceOnly: true


### PR DESCRIPTION
See: https://gist.github.com/joemiller/68ab3f7a7a08e4a9d5ad5d023cb14fc2
Docs: https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/#socket-loadbalancer-bypass-in-pod-namespace

Might even fix https://github.com/martinohmann/home-ops/issues/379 too.