### PR TITLE
chore(authentik): add wildcard certificates for outposts

### DIFF
--- a/kubernetes/main/apps/identity/authentik/app/certificate.yaml
+++ b/kubernetes/main/apps/identity/authentik/app/certificate.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.18b.haus/cert-manager.io/certificate_v1.json
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: authentik-outpost
+spec:
+  secretName: authentik-outpost-tls
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  commonName: 18b.haus
+  dnsNames:
+    - "18b.haus"
+    - "*.18b.haus"

--- a/kubernetes/main/apps/identity/authentik/app/kustomization.yaml
+++ b/kubernetes/main/apps/identity/authentik/app/kustomization.yaml
@@ -4,5 +4,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./secret.sops.yaml
+  - ./certificate.yaml
   - ./helmrelease.yaml
   - ../../../../templates/gatus/external

--- a/kubernetes/main/apps/identity/authentik/ks.yaml
+++ b/kubernetes/main/apps/identity/authentik/ks.yaml
@@ -11,6 +11,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: cert-manager-issuers
     - name: cloudnative-pg-cluster
   path: ./kubernetes/main/apps/identity/authentik/app
   prune: true

--- a/kubernetes/storage/apps/identity/authentik-remote-cluster/app/certificate.yaml
+++ b/kubernetes/storage/apps/identity/authentik-remote-cluster/app/certificate.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.18b.haus/cert-manager.io/certificate_v1.json
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: authentik-outpost
+spec:
+  secretName: authentik-outpost-tls
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  commonName: 18b.haus
+  dnsNames:
+    - "18b.haus"
+    - "*.18b.haus"
+    - "*.storage.18b.haus"

--- a/kubernetes/storage/apps/identity/authentik-remote-cluster/app/kustomization.yaml
+++ b/kubernetes/storage/apps/identity/authentik-remote-cluster/app/kustomization.yaml
@@ -3,4 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./certificate.yaml
   - ./helmrelease.yaml

--- a/kubernetes/storage/apps/identity/authentik-remote-cluster/ks.yaml
+++ b/kubernetes/storage/apps/identity/authentik-remote-cluster/ks.yaml
@@ -10,6 +10,8 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cert-manager-issuers
   path: ./kubernetes/storage/apps/identity/authentik-remote-cluster/app
   prune: true
   sourceRef:

--- a/terraform/authentik/outposts.tf
+++ b/terraform/authentik/outposts.tf
@@ -1,20 +1,17 @@
 locals {
   outpost_config = jsonencode({
-    authentik_host          = "https://identity.18b.haus/",
-    authentik_host_insecure = false,
-    authentik_host_browser  = "",
-    log_level               = "debug",
-    object_naming_template  = "authentik-outpost-proxy",
-    docker_network          = null,
-    docker_map_ports        = true,
-    docker_labels           = null,
-    container_image         = null,
-    kubernetes_replicas     = 1,
-    kubernetes_namespace    = "identity",
-    kubernetes_ingress_annotations = {
-      "cert-manager.io/cluster-issuer" = "letsencrypt-production"
-    },
-    kubernetes_ingress_secret_name = "authentik-outpost-proxy-tls",
+    authentik_host                 = "https://identity.18b.haus/",
+    authentik_host_insecure        = false,
+    authentik_host_browser         = "",
+    log_level                      = "debug",
+    object_naming_template         = "authentik-outpost-proxy",
+    docker_network                 = null,
+    docker_map_ports               = true,
+    docker_labels                  = null,
+    container_image                = null,
+    kubernetes_replicas            = 1,
+    kubernetes_namespace           = "identity",
+    kubernetes_ingress_secret_name = "authentik-outpost-tls",
     kubernetes_service_type        = "ClusterIP",
     kubernetes_disabled_components = [],
     kubernetes_image_pull_secrets  = []


### PR DESCRIPTION
This will avoid the creation of completely new certificates when a hostname is added or removed from an outpost proxy.