### PR TITLE
chore(volsync): set moverResources

### DIFF
--- a/kubernetes/main/apps/default/nextcloud/app/replicationsource.yaml
+++ b/kubernetes/main/apps/default/nextcloud/app/replicationsource.yaml
@@ -24,6 +24,9 @@ spec:
       daily: 7
       weekly: 4
       monthly: 6
+    moverResources:
+      requests:
+        memory: 1Gi
     moverSecurityContext:
       fsGroup: 82
       runAsGroup: 82
@@ -54,6 +57,9 @@ spec:
     retain:
       weekly: 4
       monthly: 6
+    moverResources:
+      requests:
+        memory: 1Gi
     moverSecurityContext:
       fsGroup: 82
       runAsGroup: 82

--- a/kubernetes/main/templates/volsync/b2.yaml
+++ b/kubernetes/main/templates/volsync/b2.yaml
@@ -21,6 +21,9 @@ spec:
     retain:
       daily: 7
       weekly: 4
+    moverResources:
+      requests:
+        memory: 1Gi
     moverSecurityContext:
       fsGroup: ${VOLSYNC_BACKUP_MOVER_FS_GROUP:-${VOLSYNC_MOVER_FS_GROUP:-568}}
       runAsGroup: ${VOLSYNC_BACKUP_MOVER_GROUP:-${VOLSYNC_MOVER_GROUP:-568}}

--- a/kubernetes/main/templates/volsync/minio.yaml
+++ b/kubernetes/main/templates/volsync/minio.yaml
@@ -23,6 +23,9 @@ spec:
       daily: 7
       weekly: 4
       monthly: 6
+    moverResources:
+      requests:
+        memory: 1Gi
     moverSecurityContext:
       fsGroup: ${VOLSYNC_BACKUP_MOVER_FS_GROUP:-${VOLSYNC_MOVER_FS_GROUP:-568}}
       runAsGroup: ${VOLSYNC_BACKUP_MOVER_GROUP:-${VOLSYNC_MOVER_GROUP:-568}}


### PR DESCRIPTION
Movers are sometimes OOMKilled, leaving behind stale restic locks that need to be cleaned manually. By setting some generous memory requests this can be avoided, I hope.