### PR TITLE
chore(storage): disable substitutions in cluster ks

### DIFF
--- a/kubernetes/storage/flux/apps.yaml
+++ b/kubernetes/storage/flux/apps.yaml
@@ -16,10 +16,6 @@ spec:
     provider: sops
     secretRef:
       name: sops-age
-  postBuild:
-    substituteFrom:
-      - kind: Secret
-        name: cluster-secrets
   patches:
     - patch: |-
         apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -38,4 +34,3 @@ spec:
       target:
         group: kustomize.toolkit.fluxcd.io
         kind: Kustomization
-        labelSelector: substitution.flux.home.arpa/disabled notin (true)

--- a/kubernetes/storage/flux/config/cluster.yaml
+++ b/kubernetes/storage/flux/config/cluster.yaml
@@ -36,7 +36,3 @@ spec:
     provider: sops
     secretRef:
       name: sops-age
-  postBuild:
-    substituteFrom:
-      - kind: Secret
-        name: cluster-secrets


### PR DESCRIPTION
It's not necessary there because these don't reference any secret variables.