### PR TITLE
fix(volsync): use longhorn-unreplicated as storage class

### DIFF
--- a/kubernetes/main/apps/default/nextcloud/app/replicationsource.yaml
+++ b/kubernetes/main/apps/default/nextcloud/app/replicationsource.yaml
@@ -17,7 +17,7 @@ spec:
     cacheStorageClassName: openebs-hostpath
     cacheAccessModes:
       - ReadWriteOnce
-    storageClassName: longhorn
+    storageClassName: longhorn-unreplicated
     accessModes:
       - ReadWriteOnce
     retain:
@@ -51,7 +51,7 @@ spec:
     cacheStorageClassName: openebs-hostpath
     cacheAccessModes:
       - ReadWriteOnce
-    storageClassName: longhorn
+    storageClassName: longhorn-unreplicated
     accessModes:
       - ReadWriteOnce
     retain:

--- a/kubernetes/main/components/volsync/local/replicationsource.yaml
+++ b/kubernetes/main/components/volsync/local/replicationsource.yaml
@@ -16,7 +16,7 @@ spec:
     cacheCapacity: "${VOLSYNC_CACHE_CAPACITY:-1Gi}"
     cacheStorageClassName: "${VOLSYNC_CACHE_STORAGECLASS:-openebs-hostpath}"
     cacheAccessModes: ["${VOLSYNC_CACHE_ACCESSMODES:-ReadWriteOnce}"]
-    storageClassName: "${VOLSYNC_STORAGECLASS:-longhorn}"
+    storageClassName: "${VOLSYNC_STORAGECLASS:-longhorn-unreplicated}"
     accessModes: ["${VOLSYNC_ACCESSMODES:-ReadWriteOnce}"]
     retain:
       hourly: 24

--- a/kubernetes/main/components/volsync/remote/replicationsource.yaml
+++ b/kubernetes/main/components/volsync/remote/replicationsource.yaml
@@ -16,7 +16,7 @@ spec:
     cacheCapacity: "${VOLSYNC_CACHE_CAPACITY:-1Gi}"
     cacheStorageClassName: "${VOLSYNC_CACHE_STORAGECLASS:-openebs-hostpath}"
     cacheAccessModes: ["${VOLSYNC_CACHE_ACCESSMODES:-ReadWriteOnce}"]
-    storageClassName: "${VOLSYNC_STORAGECLASS:-longhorn}"
+    storageClassName: "${VOLSYNC_STORAGECLASS:-longhorn-unreplicated}"
     accessModes: ["${VOLSYNC_ACCESSMODES:-ReadWriteOnce}"]
     retain:
       daily: 7


### PR DESCRIPTION
We don't need to replicate the temporary backup volumes.