### PR TITLE
feat(external-apps): attach gethomepage annotations

### DIFF
--- a/kubernetes/main/apps/default/homepage/app/configmap.yaml
+++ b/kubernetes/main/apps/default/homepage/app/configmap.yaml
@@ -16,22 +16,6 @@ data:
   kubernetes.yaml: |
     mode: cluster
   services.yaml: |
-    - Infrastructure:
-        - AdGuard Home:
-            href: https://adguard.18b.haus
-            icon: adguard-home.png
-        - Fritz!Box:
-            href: https://fritzbox.18b.haus
-            icon: fritzbox.png
-        - OPNsense:
-            href: https://opnsense.18b.haus
-            icon: opnsense.png
-        - PiKVM:
-            href: https://pikvm.18b.haus
-            icon: pikvm.png
-        - Proxmox VE:
-            href: https://pve.18b.haus
-            icon: proxmox.png
     - Observability:
         - Prometheus (storage):
             href: https://prometheus.storage.18b.haus

--- a/kubernetes/main/apps/networking/external-apps/config/adguard.yaml
+++ b/kubernetes/main/apps/networking/external-apps/config/adguard.yaml
@@ -11,6 +11,12 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/external: "true"
+    gethomepage.dev/group: Infrastructure
+    gethomepage.dev/icon: adguard-home.png
+    gethomepage.dev/name: AdGuard Home
   name: adguard
 spec:
   ingressClassName: internal

--- a/kubernetes/main/apps/networking/external-apps/config/fritzbox.yaml
+++ b/kubernetes/main/apps/networking/external-apps/config/fritzbox.yaml
@@ -12,6 +12,11 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/external: "true"
+    gethomepage.dev/group: Infrastructure
+    gethomepage.dev/icon: fritzbox.png
+    gethomepage.dev/name: Fritz!Box
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/upstream-vhost: fritz.box
   name: fritzbox

--- a/kubernetes/main/apps/networking/external-apps/config/opnsense.yaml
+++ b/kubernetes/main/apps/networking/external-apps/config/opnsense.yaml
@@ -12,6 +12,11 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/external: "true"
+    gethomepage.dev/group: Infrastructure
+    gethomepage.dev/icon: opnsense.png
+    gethomepage.dev/name: OPNsense
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
   name: opnsense
 spec:

--- a/kubernetes/main/apps/networking/external-apps/config/pikvm.yaml
+++ b/kubernetes/main/apps/networking/external-apps/config/pikvm.yaml
@@ -12,6 +12,11 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/external: "true"
+    gethomepage.dev/group: Infrastructure
+    gethomepage.dev/icon: pikvm.png
+    gethomepage.dev/name: PiKVM
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
   name: pikvm
 spec:

--- a/kubernetes/main/apps/networking/external-apps/config/pve.yaml
+++ b/kubernetes/main/apps/networking/external-apps/config/pve.yaml
@@ -34,6 +34,11 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/external: "true"
+    gethomepage.dev/group: Infrastructure
+    gethomepage.dev/icon: proxmox.png
+    gethomepage.dev/name: Proxmox VE
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/upstream-hash-by: $host
   name: pve


### PR DESCRIPTION
I just learned there is the `gethomepage.dev/external` annotation which allows disabling the pod health checks, which always blocked me from doing this.