### PR TITLE
fix(gatus): remove `internal` group

### DIFF
--- a/kubernetes/main/apps/default/forgejo/ks.yaml
+++ b/kubernetes/main/apps/default/forgejo/ks.yaml
@@ -59,7 +59,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      GATUS_PATH: /api/healthz
       GATUS_SUBDOMAIN: git
       VOLSYNC_CAPACITY: 20Gi
       VOLSYNC_MOVER_FS_GROUP: "1000"

--- a/kubernetes/main/apps/default/nextcloud/ks.yaml
+++ b/kubernetes/main/apps/default/nextcloud/ks.yaml
@@ -33,7 +33,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      GATUS_PATH: /status.php
       GATUS_SUBDOMAIN: cloud
       VOLSYNC_CAPACITY: 2Gi
       VOLSYNC_MOVER_FS_GROUP: "82"

--- a/kubernetes/main/apps/default/zigbee2mqtt/ks.yaml
+++ b/kubernetes/main/apps/default/zigbee2mqtt/ks.yaml
@@ -27,7 +27,6 @@ spec:
     substitute:
       APP: *app
       GATUS_SUBDOMAIN: zigbee
-      GATUS_URL: http://zigbee2mqtt.default.svc.cluster.local
       VOLSYNC_CAPACITY: 1Gi
       VOLSYNC_SCHEDULE_B2: '15 2 * * 0'
       VOLSYNC_SCHEDULE_MINIO: '15 */4 * * *'

--- a/kubernetes/main/apps/monitoring/gatus/app/resources/config.yaml
+++ b/kubernetes/main/apps/monitoring/gatus/app/resources/config.yaml
@@ -48,17 +48,6 @@ endpoints:
       - type: telegram
   # Services in storage cluster.
   - name: minio
-    group: internal
-    url: https://s3.storage.18b.haus/minio/health/live
-    interval: 2m
-    ui:
-      hide-hostname: true
-      hide-url: true
-    conditions:
-      - "[STATUS] == 200"
-    alerts:
-      - type: telegram
-  - name: minio
     group: guarded
     url: 1.1.1.1
     interval: 1m

--- a/kubernetes/main/components/gatus/internal/config.yaml
+++ b/kubernetes/main/components/gatus/internal/config.yaml
@@ -1,16 +1,5 @@
 endpoints:
   - name: "${APP}"
-    group: internal
-    url: "${GATUS_URL:-https://${GATUS_SUBDOMAIN:-${APP}}.18b.haus${GATUS_PATH:-/}}"
-    interval: 2m
-    ui:
-      hide-hostname: true
-      hide-url: true
-    conditions:
-      - "[STATUS] == ${GATUS_STATUS:-200}"
-    alerts:
-      - type: telegram
-  - name: "${APP}"
     group: guarded
     url: 1.1.1.1
     interval: 1m


### PR DESCRIPTION
The `guarded` DNS checks should be enough here. If things are down I'll notice by other means.