### PR TITLE
feat(external-apps): switch to EndpointSlices

### DIFF
--- a/kubernetes/main/apps/networking/external-apps/config/adguard.yaml
+++ b/kubernetes/main/apps/networking/external-apps/config/adguard.yaml
@@ -4,8 +4,28 @@ kind: Service
 metadata:
   name: adguard
 spec:
-  externalName: adguard.18b.lan.
-  type: ExternalName
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 3000
+
+---
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: adguard
+  labels:
+    kubernetes.io/service-name: adguard
+addressType: IPv4
+ports:
+  - name: http
+    appProtocol: http
+    protocol: TCP
+    port: 3000
+endpoints:
+  - addresses:
+      - 192.168.1.1
 
 ---
 apiVersion: networking.k8s.io/v1
@@ -28,7 +48,7 @@ spec:
               service:
                 name: adguard
                 port:
-                  number: 3000
+                  name: http
             path: /
             pathType: Prefix
   tls:

--- a/kubernetes/main/apps/networking/external-apps/config/fritzbox.yaml
+++ b/kubernetes/main/apps/networking/external-apps/config/fritzbox.yaml
@@ -4,8 +4,28 @@ kind: Service
 metadata:
   name: fritzbox
 spec:
-  externalName: fritz.box.
-  type: ExternalName
+  ports:
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: 443
+
+---
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: fritzbox
+  labels:
+    kubernetes.io/service-name: fritzbox
+addressType: IPv4
+ports:
+  - name: https
+    appProtocol: https
+    protocol: TCP
+    port: 443
+endpoints:
+  - addresses:
+      - 192.168.178.1
 
 ---
 apiVersion: networking.k8s.io/v1
@@ -30,7 +50,7 @@ spec:
               service:
                 name: fritzbox
                 port:
-                  number: 443
+                  name: https
             path: /
             pathType: Prefix
   tls:

--- a/kubernetes/main/apps/networking/external-apps/config/opnsense.yaml
+++ b/kubernetes/main/apps/networking/external-apps/config/opnsense.yaml
@@ -4,8 +4,28 @@ kind: Service
 metadata:
   name: opnsense
 spec:
-  externalName: opnsense.18b.lan.
-  type: ExternalName
+  ports:
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: 443
+
+---
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: opnsense
+  labels:
+    kubernetes.io/service-name: opnsense
+addressType: IPv4
+ports:
+  - name: https
+    appProtocol: https
+    protocol: TCP
+    port: 443
+endpoints:
+  - addresses:
+      - 192.168.1.1
 
 ---
 apiVersion: networking.k8s.io/v1
@@ -29,7 +49,7 @@ spec:
               service:
                 name: opnsense
                 port:
-                  number: 443
+                  name: https
             path: /
             pathType: Prefix
   tls:

--- a/kubernetes/main/apps/networking/external-apps/config/pikvm.yaml
+++ b/kubernetes/main/apps/networking/external-apps/config/pikvm.yaml
@@ -4,8 +4,28 @@ kind: Service
 metadata:
   name: pikvm
 spec:
-  externalName: pikvm.18b.lan.
-  type: ExternalName
+  ports:
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: 443
+
+---
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: pikvm
+  labels:
+    kubernetes.io/service-name: pikvm
+addressType: IPv4
+ports:
+  - name: https
+    appProtocol: https
+    protocol: TCP
+    port: 443
+endpoints:
+  - addresses:
+      - 192.168.1.30
 
 ---
 apiVersion: networking.k8s.io/v1
@@ -29,7 +49,7 @@ spec:
               service:
                 name: pikvm
                 port:
-                  number: 443
+                  name: https
             path: /
             pathType: Prefix
   tls:

--- a/kubernetes/main/apps/networking/external-apps/config/pve.yaml
+++ b/kubernetes/main/apps/networking/external-apps/config/pve.yaml
@@ -52,7 +52,7 @@ spec:
               service:
                 name: pve
                 port:
-                  number: 443
+                  name: https
             path: /
             pathType: Prefix
   tls:


### PR DESCRIPTION
I have a fair amount of unnecessary DNS traffic in my network because of the `ExternalName` services. Since all of the external apps have static IPs I might as well just point to these directly.