### PR TITLE
fix(kps): shorter resource names

### DIFF
--- a/kubernetes/storage/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/storage/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -35,6 +35,7 @@ spec:
         enabled: true
         forceConflicts: true
     cleanPrometheusOperatorObjectNames: true
+    fullnameOverride: kps
     alertmanager:
       enabled: false
     kubelet:


### PR DESCRIPTION
Let's see what this breaks.

`prometheus-kps-db-prometheus-kps-0` would be certainly less annoying than `prometheus-kube-prometheus-stack-db-prometheus-kube-prometheus-stack-0`...