### PR TITLE
fix(longhorn): rename volsync storage class

### DIFF
--- a/kubernetes/main/apps/default/nextcloud/app/replicationsource.yaml
+++ b/kubernetes/main/apps/default/nextcloud/app/replicationsource.yaml
@@ -17,7 +17,7 @@ spec:
     cacheStorageClassName: openebs-hostpath
     cacheAccessModes:
       - ReadWriteOnce
-    storageClassName: longhorn-unreplicated
+    storageClassName: longhorn-volsync
     accessModes:
       - ReadWriteOnce
     retain:
@@ -51,7 +51,7 @@ spec:
     cacheStorageClassName: openebs-hostpath
     cacheAccessModes:
       - ReadWriteOnce
-    storageClassName: longhorn-unreplicated
+    storageClassName: longhorn-volsync
     accessModes:
       - ReadWriteOnce
     retain:

--- a/kubernetes/main/apps/longhorn-system/longhorn/app/storageclass.yaml
+++ b/kubernetes/main/apps/longhorn-system/longhorn/app/storageclass.yaml
@@ -3,7 +3,7 @@ allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: longhorn-unreplicated
+  name: longhorn-volsync
   annotations:
     storageclass.kubernetes.io/is-default-class: "false"
 parameters:

--- a/kubernetes/main/components/volsync/local/replicationsource.yaml
+++ b/kubernetes/main/components/volsync/local/replicationsource.yaml
@@ -16,7 +16,7 @@ spec:
     cacheCapacity: "${VOLSYNC_CACHE_CAPACITY:-1Gi}"
     cacheStorageClassName: "${VOLSYNC_CACHE_STORAGECLASS:-openebs-hostpath}"
     cacheAccessModes: ["${VOLSYNC_CACHE_ACCESSMODES:-ReadWriteOnce}"]
-    storageClassName: "${VOLSYNC_STORAGECLASS:-longhorn-unreplicated}"
+    storageClassName: "${VOLSYNC_STORAGECLASS:-longhorn-volsync}"
     accessModes: ["${VOLSYNC_ACCESSMODES:-ReadWriteOnce}"]
     retain:
       hourly: 24

--- a/kubernetes/main/components/volsync/remote/replicationsource.yaml
+++ b/kubernetes/main/components/volsync/remote/replicationsource.yaml
@@ -16,7 +16,7 @@ spec:
     cacheCapacity: "${VOLSYNC_CACHE_CAPACITY:-1Gi}"
     cacheStorageClassName: "${VOLSYNC_CACHE_STORAGECLASS:-openebs-hostpath}"
     cacheAccessModes: ["${VOLSYNC_CACHE_ACCESSMODES:-ReadWriteOnce}"]
-    storageClassName: "${VOLSYNC_STORAGECLASS:-longhorn-unreplicated}"
+    storageClassName: "${VOLSYNC_STORAGECLASS:-longhorn-volsync}"
     accessModes: ["${VOLSYNC_ACCESSMODES:-ReadWriteOnce}"]
     retain:
       daily: 7


### PR DESCRIPTION
Technically it's still replicated, but less than the normal `longhorn` storage class.

Rename `longhorn-unreplicated` to `longhorn-volsync` to avoid confusion.