### PR TITLE
fix(longhorn): patch ServiceAccount with imagePullSecrets

### DIFF
--- a/kubernetes/main/apps/longhorn-system/longhorn/app/helmrelease.yaml
+++ b/kubernetes/main/apps/longhorn-system/longhorn/app/helmrelease.yaml
@@ -73,3 +73,16 @@ spec:
         enabled: true
     privateRegistry:
       registrySecret: dockerhub-auth
+  postRenderers:
+    - kustomize:
+        patches:
+          # Add dockerhub-auth imagePullSecret to ServiceAccounts.
+          - target:
+              kind: ServiceAccount
+            patch: |
+              apiVersion: v1
+              kind: ServiceAccount
+              metadata:
+                name: not-used
+              imagePullSecrets:
+                - name: dockerhub-auth


### PR DESCRIPTION
The chart's support for imagePullSecrets is incomplete and does not cover all components, but luckily all of them use ServiceAccounts, so we can add the imagePullSecrets to these.